### PR TITLE
Add JSON_RemoveNode and JSON_RemoveIndex

### DIFF
--- a/json.inc
+++ b/json.inc
@@ -81,6 +81,12 @@ native Node:operator+(Node:a, Node:b) = JSON_Append;
 // JSON_Remove removes any existing key from your node.
 native JSON_Remove(Node:node, const key[]);
 
+// JSON_RemoveNode removes `input` from array `node`
+native JSON_RemoveNode(Node:node, Node:input);
+
+// JSON_RemoveIndex removes the element at `index` from array `node`
+native JSON_RemoveIndex(Node:node, index);
+
 // JSON_Set* functions directly modify nodes by inserting or modifying keys.
 native JSON_SetObject(Node:node, const key[], Node:object);
 native JSON_SetArray(Node:node, const key[], Node:array);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ initialize_plugin!(
             Plugin::json_array_clear,
             Plugin::json_keys,
             Plugin::json_remove,
+            Plugin::json_remove_node,
+            Plugin::json_remove_index,
             Plugin::json_get_node_int,
             Plugin::json_get_node_float,
             Plugin::json_get_node_bool,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -818,6 +818,39 @@ impl Plugin {
         Ok(0)
     }
 
+    #[native(name = "JSON_RemoveNode")]
+    pub fn json_remove_node(&mut self, _: &Amx, node: i32, input: i32) -> AmxResult<i32> {
+        let src: serde_json::Value = match self.json_nodes.get(input) {
+            Some(src) => src.clone(),
+            None => return Ok(1)
+        };
+        let v: &mut serde_json::Value = match self.json_nodes.get(node) {
+            Some(v) => v,
+            None => return Ok(2),
+        };
+        if !v.is_array() {
+            return Ok(3);
+        }
+        v.as_array_mut().unwrap().retain(|val| *val != src);
+        Ok(0)
+    }
+
+    #[native(name = "JSON_RemoveIndex")]
+    pub fn json_remove_index(&mut self, _: &Amx, node: i32, index: usize) -> AmxResult<i32> {
+        let v: &mut serde_json::Value = match self.json_nodes.get(node) {
+            Some(v) => v,
+            None => return Ok(1),
+        };
+        if !v.is_array() {
+            return Ok(2)
+        }
+        if index >= v.as_array().unwrap().len() {
+            return Ok(3)
+        }
+        v.as_array_mut().unwrap().remove(index);
+        Ok(0)
+    }
+
     #[native(name = "JSON_GetNodeInt")]
     pub fn json_get_node_int(
         &mut self,


### PR DESCRIPTION
Directly remove element from array node with no need to have an array to stored in an object

```pwn
new Node:a = JSON_Array(JSON_Int(1), JSON_Int(2), JSON_Int(3)); // a = [1, 2, 3]
JSON_RemoveNode(a, JSON_Int(2)); // a = [1, 3]
JSON_RemoveIndex(a, 1); // a = [1]
```