### PR TITLE
Use docker for building on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,21 +44,20 @@ jobs:
           path: artifacts/
 
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RUST: i686-unknown-linux-gnu
       RELEASE_BIN: libpawn_json
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install gcc-multilib
-        run: sudo apt update && sudo apt install gcc-multilib -y
-
-      - name: Install Rust (rustup)
-        run: rustup target add ${{ env.RUST }}
-
-      - name: Build
-        run: cargo build --release --target ${{ env.RUST }}
+      - name: Build using Docker
+        shell: bash
+        run: |
+          cd docker
+          chmod +x ./build.sh
+          chmod +x ./docker-entrypoint.sh
+          ./build.sh
 
       - name: Create artifacts directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,21 +50,20 @@ jobs:
           asset_content_type: application/gzip
 
   release-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RUST: i686-unknown-linux-gnu
       RELEASE_BIN: libpawn_json
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install gcc-multilib
-        run: sudo apt update && sudo apt install gcc-multilib -y
-
-      - name: Install Rust (rustup)
-        run: rustup target add ${{ env.RUST }}
-
-      - name: Build
-        run: cargo build --release --target ${{ env.RUST }}
+      - name: Build using Docker
+        shell: bash
+        run: |
+          cd docker
+          chmod +x ./build.sh
+          chmod +x ./docker-entrypoint.sh
+          ./build.sh
 
       - name: Create artifacts directory
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y gcc-multilib curl
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add i686-unknown-linux-gnu
+
+COPY docker-entrypoint.sh /
+CMD ["/docker-entrypoint.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+docker build \
+    -t pawn-json/build:ubuntu-18.04 ./ \
+|| exit 1
+
+docker run \
+    --rm \
+    -t \
+    -w /code \
+    -v $PWD/..:/code \
+    pawn-json/build:ubuntu-18.04

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cargo build --release --target i686-unknown-linux-gnu


### PR DESCRIPTION
This PR will update the current CI for Linux to use Docker since the ubuntu-20.04 is now deprecated as per https://github.com/actions/runner-images/issues/11101.